### PR TITLE
Add custom SCALE-compact encoding

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -71,6 +71,8 @@
 // TODO: consider rewriting the encoding/decoding into a more legible style
 // TODO: consider nom for decoding
 
+use crate::util;
+
 use alloc::{vec, vec::Vec};
 use core::{convert::TryFrom, fmt, iter, slice};
 
@@ -479,13 +481,10 @@ impl<'a> DigestRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        // TODO: don't allocate?
-        let len = u64::try_from(self.logs().len()).unwrap();
-        let encoded_len = parity_scale_codec::Encode::encode(&parity_scale_codec::Compact(len));
-
-        iter::once(either::Either::Left(encoded_len)).chain(
+        let encoded_len = util::encode_scale_compact_usize(self.logs().len());
+        iter::once(either::Left(encoded_len)).chain(
             self.logs()
-                .flat_map(|v| v.scale_encoding().map(either::Either::Right)),
+                .flat_map(|v| v.scale_encoding().map(either::Right)),
         )
     }
 
@@ -746,9 +745,7 @@ impl<'a> DigestItemRef<'a> {
 
                 let mut ret = vec![4];
                 ret.extend_from_slice(b"BABE");
-                ret.extend_from_slice(&parity_scale_codec::Encode::encode(
-                    &parity_scale_codec::Compact(u64::try_from(encoded.len()).unwrap()),
-                ));
+                ret.extend_from_slice(util::encode_scale_compact_usize(encoded.len()).as_ref());
                 ret.extend_from_slice(&encoded);
                 iter::once(ret)
             }
@@ -760,9 +757,7 @@ impl<'a> DigestItemRef<'a> {
 
                 let mut ret = vec![4];
                 ret.extend_from_slice(b"FRNK");
-                ret.extend_from_slice(&parity_scale_codec::Encode::encode(
-                    &parity_scale_codec::Compact(u64::try_from(encoded.len()).unwrap()),
-                ));
+                ret.extend_from_slice(util::encode_scale_compact_usize(encoded.len()).as_ref());
                 ret.extend_from_slice(&encoded);
                 iter::once(ret)
             }
@@ -771,9 +766,7 @@ impl<'a> DigestItemRef<'a> {
 
                 let mut ret = vec![5];
                 ret.extend_from_slice(b"BABE");
-                ret.extend_from_slice(&parity_scale_codec::Encode::encode(
-                    &parity_scale_codec::Compact(64u32),
-                ));
+                ret.extend_from_slice(util::encode_scale_compact_usize(64).as_ref());
                 ret.extend_from_slice(seal);
                 iter::once(ret)
             }

--- a/src/header/babe.rs
+++ b/src/header/babe.rs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Error;
+use crate::util;
 
 use alloc::vec::Vec;
 use core::{cmp, convert::TryFrom, fmt, iter, slice};
@@ -163,19 +164,15 @@ impl<'a> BabeNextEpochRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        // TODO: don't allocate
-        let header = parity_scale_codec::Encode::encode(&parity_scale_codec::Compact(
-            u64::try_from(self.authorities.len()).unwrap(),
-        ));
-
-        iter::once(either::Either::Left(header))
+        let header = util::encode_scale_compact_usize(self.authorities.len());
+        iter::once(either::Left(header))
             .chain(
                 self.authorities
                     .clone()
                     .flat_map(|a| a.scale_encoding())
-                    .map(|buf| either::Either::Right(either::Either::Left(buf))),
+                    .map(|buf| either::Right(either::Left(buf))),
             )
-            .chain(iter::once(either::Either::Right(either::Either::Right(
+            .chain(iter::once(either::Right(either::Right(
                 &self.randomness[..],
             ))))
     }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -226,19 +226,14 @@ mod tests {
         let mut trie = Trie::new();
         trie.insert(&[0xaa], [0xbb].to_vec());
 
-        fn to_compact(n: u8) -> u8 {
-            use parity_scale_codec::Encode as _;
-            parity_scale_codec::Compact(n).encode()[0]
-        }
-
         let expected = blake2_rfc::blake2b::blake2b(
             32,
             &[],
             &[
-                0x42,          // leaf 0x40 (2^6) with (+) key of 2 nibbles (0x02)
-                0xaa,          // key data
-                to_compact(1), // length of value in bytes as Compact
-                0xbb,          // value data
+                0x42,   // leaf 0x40 (2^6) with (+) key of 2 nibbles (0x02)
+                0xaa,   // key data
+                1 << 2, // length of value in bytes as Compact
+                0xbb,   // value data
             ],
         );
 
@@ -251,26 +246,21 @@ mod tests {
         trie.insert(&[0x48, 0x19], [0xfe].to_vec());
         trie.insert(&[0x13, 0x14], [0xff].to_vec());
 
-        fn to_compact(n: u8) -> u8 {
-            use parity_scale_codec::Encode as _;
-            parity_scale_codec::Compact(n).encode()[0]
-        }
-
         let mut ex = Vec::<u8>::new();
         ex.push(0x80); // branch, no value (0b_10..) no nibble
         ex.push(0x12); // slots 1 & 4 are taken from 0-7
         ex.push(0x00); // no slots from 8-15
-        ex.push(to_compact(0x05)); // first slot: LEAF, 5 bytes long.
+        ex.push(0x05 << 2); // first slot: LEAF, 5 bytes long.
         ex.push(0x43); // leaf 0x40 with 3 nibbles
         ex.push(0x03); // first nibble
         ex.push(0x14); // second & third nibble
-        ex.push(to_compact(0x01)); // 1 byte data
+        ex.push(0x01 << 2); // 1 byte data
         ex.push(0xff); // value data
-        ex.push(to_compact(0x05)); // second slot: LEAF, 5 bytes long.
+        ex.push(0x05 << 2); // second slot: LEAF, 5 bytes long.
         ex.push(0x43); // leaf with 3 nibbles
         ex.push(0x08); // first nibble
         ex.push(0x19); // second & third nibble
-        ex.push(to_compact(0x01)); // 1 byte data
+        ex.push(0x01 << 2); // 1 byte data
         ex.push(0xfe); // value data
 
         let expected = blake2_rfc::blake2b::blake2b(32, &[], &ex);

--- a/src/trie/node_value.rs
+++ b/src/trie/node_value.rs
@@ -69,10 +69,10 @@
 //! ```
 
 use super::nibble::Nibble;
+use crate::util;
 
 use arrayvec::ArrayVec;
 use core::{convert::TryFrom as _, fmt};
-use parity_scale_codec::Encode as _;
 
 /// Information about a node whose Merkle value is to be calculated.
 ///
@@ -203,8 +203,8 @@ where
             // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
             // quite expensive because we would duplicate the storage value. Instead, we do the
             // encoding manually by pushing the length then the value.
-            parity_scale_codec::Compact(u64::try_from(stored_value.as_ref().len()).unwrap())
-                .encode_to(&mut merkle_value_sink);
+            merkle_value_sink
+                .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
             merkle_value_sink.update(stored_value.as_ref());
         }
 
@@ -232,8 +232,8 @@ where
         // Doing something like `merkle_value_sink.update(child_merkle_value.encode());` would be
         // expensive because we would duplicate the merkle value. Instead, we do the encoding
         // manually by pushing the length then the value.
-        parity_scale_codec::Compact(u64::try_from(child_merkle_value.as_ref().len()).unwrap())
-            .encode_to(&mut merkle_value_sink);
+        merkle_value_sink
+            .update(util::encode_scale_compact_usize(child_merkle_value.as_ref().len()).as_ref());
         merkle_value_sink.update(child_merkle_value.as_ref());
     }
 
@@ -242,8 +242,8 @@ where
         // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
         // quite expensive because we would duplicate the storage value. Instead, we do the
         // encoding manually by pushing the length then the value.
-        parity_scale_codec::Compact(u64::try_from(stored_value.as_ref().len()).unwrap())
-            .encode_to(&mut merkle_value_sink);
+        merkle_value_sink
+            .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
         merkle_value_sink.update(stored_value.as_ref());
     }
 
@@ -343,12 +343,6 @@ impl HashOrInline {
                 HashOrInline::Hasher(h) => OutputInner::Hasher(h.finalize()),
             },
         }
-    }
-}
-
-impl parity_scale_codec::Output for HashOrInline {
-    fn write(&mut self, bytes: &[u8]) {
-        self.update(bytes);
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,3 +92,30 @@ pub(crate) fn nom_scale_compact_usize<'a, E: nom::error::ParseError<&'a [u8]>>(
         _ => unreachable!(),
     }
 }
+
+/// Returns a buffer containing the SCALE-compact encoding of the parameter.
+pub(crate) fn encode_scale_compact_usize(mut value: usize) -> impl AsRef<[u8]> + Clone {
+    // TODO: use usize::BITS after https://github.com/rust-lang/rust/issues/76904 is stable
+    let mut array = arrayvec::ArrayVec::<[u8; 1 + 64 / 8]>::new();
+
+    if value < 64 {
+        array.push(u8::try_from(value).unwrap() << 2);
+    } else if value < (1 << 14) {
+        array.push((u8::try_from(value & 0b111111).unwrap() << 2) | 0b01);
+        array.push(u8::try_from((value >> 6) & 0xff).unwrap());
+    } else if value < (1 << 30) {
+        array.push((u8::try_from(value & 0b111111).unwrap() << 2) | 0b10);
+        array.push(u8::try_from((value >> 6) & 0xff).unwrap());
+        array.push(u8::try_from((value >> 14) & 0xff).unwrap());
+        array.push(u8::try_from((value >> 22) & 0xff).unwrap());
+    } else {
+        array.push(0);
+        while value != 0 {
+            array.push(u8::try_from(value & 0xff).unwrap());
+            value >>= 8;
+        }
+        array[0] = (u8::try_from(array.len() - 1 - 4).unwrap() << 2) & 0b11;
+    }
+
+    array
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,7 +114,7 @@ pub(crate) fn encode_scale_compact_usize(mut value: usize) -> impl AsRef<[u8]> +
             array.push(u8::try_from(value & 0xff).unwrap());
             value >>= 8;
         }
-        array[0] = (u8::try_from(array.len() - 1 - 4).unwrap() << 2) & 0b11;
+        array[0] = (u8::try_from(array.len() - 1 - 4).unwrap() << 2) | 0b11;
     }
 
     array


### PR DESCRIPTION
Removes most usage of `parity_scale_codec::Compact`.

This saves allocating `Vec`s all the time, and also avoids having to convert `usize`s to `u64`s all the time.
