### PR TITLE
Quickfix for Kusama syncing malfunction

### DIFF
--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -132,7 +132,8 @@ impl JitPrototype {
                     // TODO: review interaction with imported memory
                     let memory = if let Some(mem) = instance.get_export("memory") {
                         if let Some(mem) = mem.into_memory() {
-                            // TODO: has to grow memory by heap_pages
+                            // TODO: do this properly
+                            mem.grow(u32::try_from(heap_pages).unwrap()).unwrap();
                             Some(mem.clone())
                         } else {
                             let err = NewErr::MemoryIsntMemory;


### PR DESCRIPTION
The entire code under the `vm` module should be re-reviewed and partially rewritten.
In the meanwhile, here's a quickfix to make Kusama sync.