### PR TITLE
Fix disconnects not being detected by network service

### DIFF
--- a/bin/full-node/main.rs
+++ b/bin/full-node/main.rs
@@ -217,6 +217,9 @@ async fn async_main() {
                     network_service::Event::Connected(peer_id) => {
                         sync_service.add_source(peer_id).await;
                     }
+                    network_service::Event::Disconnected(peer_id) => {
+                        sync_service.remove_source(peer_id).await;
+                    }
                 }
             }
 

--- a/bin/full-node/network_service.rs
+++ b/bin/full-node/network_service.rs
@@ -69,6 +69,7 @@ pub struct Config {
 #[derive(Debug)]
 pub enum Event {
     Connected(PeerId),
+    Disconnected(PeerId),
 }
 
 pub struct NetworkService {
@@ -313,11 +314,10 @@ impl NetworkService {
                 }
                 FromBackground::Disconnected { connection_id } => {
                     let mut guarded = self.guarded.lock().await;
-                    guarded
-                        .peerset
-                        .connection_mut(connection_id)
-                        .unwrap()
-                        .remove();
+                    let connection = guarded.peerset.connection_mut(connection_id).unwrap();
+                    let peer_id = connection.peer_id().clone(); // TODO: clone :(
+                    connection.remove();
+                    return Event::Disconnected(peer_id);
                 }
                 FromBackground::NotificationsOpenResult {
                     connection_id,
@@ -466,10 +466,12 @@ async fn connection_task(
     let tcp_socket = match tcp_socket.await {
         Ok(s) => s,
         Err(_) => {
-            let _ = to_foreground.send(FromBackground::HandshakeError {
-                connection_id,
-                error: HandshakeError::Io,
-            });
+            let _ = to_foreground
+                .send(FromBackground::HandshakeError {
+                    connection_id,
+                    error: HandshakeError::Io,
+                })
+                .await;
             return;
         }
     };
@@ -494,10 +496,12 @@ async fn connection_task(
         match perform_handshake(&mut tcp_socket, &noise_key, is_initiator).await {
             Ok(v) => v,
             Err(error) => {
-                let _ = to_foreground.send(FromBackground::HandshakeError {
-                    connection_id,
-                    error,
-                });
+                let _ = to_foreground
+                    .send(FromBackground::HandshakeError {
+                        connection_id,
+                        error,
+                    })
+                    .await;
                 return;
             }
         };
@@ -548,7 +552,9 @@ async fn connection_task(
         let (read_buffer, write_buffer) = match tcp_socket.buffers() {
             Ok(b) => b,
             Err(_) => {
-                let _ = to_foreground.send(FromBackground::Disconnected { connection_id });
+                let _ = to_foreground
+                    .send(FromBackground::Disconnected { connection_id })
+                    .await;
                 return;
             }
         };
@@ -559,7 +565,9 @@ async fn connection_task(
             match connection.read_write(now, read_buffer.map(|b| b.0), write_buffer.unwrap()) {
                 Ok(rw) => rw,
                 Err(_) => {
-                    let _ = to_foreground.send(FromBackground::Disconnected { connection_id });
+                    let _ = to_foreground
+                        .send(FromBackground::Disconnected { connection_id })
+                        .await;
                     return;
                 }
             };


### PR DESCRIPTION
The sync stalling is simply because I forgot a couple of `await`s.
Ignoring warnings has once again bitten me in the arse.
