### PR TITLE
Publish substrate-lite 0.1.2 on npm

### DIFF
--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-lite",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",


### PR DESCRIPTION
It's already published. This PR bumps the version.