### PR TITLE
Allow for different finality engines

### DIFF
--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -276,8 +276,8 @@ pub enum ChainInformationFinality {
         /// Contains the block number where the changes are to be triggered.
         ///
         /// The block whose height is contained in this field must still be finalized using the
-        /// authorities found in [`ChainInformation::grandpa_finalized_triggered_authorities`]. Only
-        /// the next block and further use the new list of authorities.
+        /// authorities found in [`ChainInformationFinality::Grandpa::finalized_triggered_authorities`].
+        /// Only the next block and further use the new list of authorities.
         ///
         /// The block height must always be strictly superior to the height found in
         /// [`ChainInformation::finalized_block_header`].

--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -57,32 +57,8 @@ pub struct ChainInformation {
     /// Extra items that depend on the consensus engine.
     pub consensus: ChainInformationConsensus,
 
-    /// Grandpa authorities set ID of the block right after finalized block.
-    ///
-    /// If the finalized block is the genesis, should be 0. Otherwise,
-    // TODO: document how to know this
-    pub grandpa_after_finalized_block_authorities_set_id: u64,
-
-    /// List of GrandPa authorities that need to finalize the block right after the finalized
-    /// block.
-    pub grandpa_finalized_triggered_authorities: Vec<header::GrandpaAuthority>,
-
-    /// Change in the GrandPa authorities list that has been scheduled by a block that is already
-    /// finalized, but the change is not triggered yet. These changes will for sure happen.
-    /// Contains the block number where the changes are to be triggered.
-    ///
-    /// The block whose height is contained in this field must still be finalized using the
-    /// authorities found in [`ChainInformation::grandpa_finalized_triggered_authorities`]. Only
-    /// the next block and further use the new list of authorities.
-    ///
-    /// The block height must always be strictly superior to the height found in
-    /// [`ChainInformation::finalized_block_header`].
-    ///
-    /// > **Note**: When a header contains a GrandPa scheduled changes log item with a delay of N,
-    /// >           the block where the changes are triggered is
-    /// >           `height(block_with_log_item) + N`. If `N` is 0, then the block where the
-    /// >           change is triggered is the same as the one where it is scheduled.
-    pub grandpa_finalized_scheduled_change: Option<(u64, Vec<header::GrandpaAuthority>)>,
+    /// Extra items that depend on the finality engine.
+    pub finality: ChainInformationFinality,
 }
 
 impl ChainInformation {
@@ -142,9 +118,11 @@ impl ChainInformation {
         Ok(ChainInformation {
             finalized_block_header: crate::calculate_genesis_block_header(genesis_storage),
             consensus,
-            grandpa_after_finalized_block_authorities_set_id: 0,
-            grandpa_finalized_scheduled_change: None,
-            grandpa_finalized_triggered_authorities: grandpa_genesis_config.initial_authorities,
+            finality: ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id: 0,
+                finalized_scheduled_change: None,
+                finalized_triggered_authorities: grandpa_genesis_config.initial_authorities,
+            },
         })
     }
 }
@@ -174,14 +152,18 @@ impl<'a> From<ChainInformationRef<'a>> for ChainInformation {
                     finalized_next_epoch_transition: finalized_next_epoch_transition.into(),
                 },
             },
-            grandpa_after_finalized_block_authorities_set_id: info
-                .grandpa_after_finalized_block_authorities_set_id,
-            grandpa_finalized_triggered_authorities: info
-                .grandpa_finalized_triggered_authorities
-                .into(),
-            grandpa_finalized_scheduled_change: info
-                .grandpa_finalized_scheduled_change
-                .map(|(n, l)| (n, l.into())),
+            finality: match info.finality {
+                ChainInformationFinalityRef::Grandpa {
+                    after_finalized_block_authorities_set_id,
+                    finalized_triggered_authorities,
+                    finalized_scheduled_change,
+                } => ChainInformationFinality::Grandpa {
+                    after_finalized_block_authorities_set_id,
+                    finalized_scheduled_change: finalized_scheduled_change
+                        .map(|(n, l)| (n, l.into())),
+                    finalized_triggered_authorities: finalized_triggered_authorities.into(),
+                },
+            },
         }
     }
 }
@@ -275,6 +257,39 @@ impl<'a> From<BabeEpochInformationRef<'a>> for BabeEpochInformation {
     }
 }
 
+/// Extra items that depend on the finality engine.
+#[derive(Debug, Clone)]
+pub enum ChainInformationFinality {
+    Grandpa {
+        /// Grandpa authorities set ID of the block right after finalized block.
+        ///
+        /// If the finalized block is the genesis, should be 0. Otherwise,
+        // TODO: document how to know this
+        after_finalized_block_authorities_set_id: u64,
+
+        /// List of GrandPa authorities that need to finalize the block right after the finalized
+        /// block.
+        finalized_triggered_authorities: Vec<header::GrandpaAuthority>,
+
+        /// Change in the GrandPa authorities list that has been scheduled by a block that is already
+        /// finalized, but the change is not triggered yet. These changes will for sure happen.
+        /// Contains the block number where the changes are to be triggered.
+        ///
+        /// The block whose height is contained in this field must still be finalized using the
+        /// authorities found in [`ChainInformation::grandpa_finalized_triggered_authorities`]. Only
+        /// the next block and further use the new list of authorities.
+        ///
+        /// The block height must always be strictly superior to the height found in
+        /// [`ChainInformation::finalized_block_header`].
+        ///
+        /// > **Note**: When a header contains a GrandPa scheduled changes log item with a delay of N,
+        /// >           the block where the changes are triggered is
+        /// >           `height(block_with_log_item) + N`. If `N` is 0, then the block where the
+        /// >           change is triggered is the same as the one where it is scheduled.
+        finalized_scheduled_change: Option<(u64, Vec<header::GrandpaAuthority>)>,
+    },
+}
+
 /// Error when building the chain information from the genesis storage.
 #[derive(Debug, derive_more::Display)]
 pub enum FromGenesisStorageError {
@@ -297,14 +312,8 @@ pub struct ChainInformationRef<'a> {
     /// Extra items that depend on the consensus engine.
     pub consensus: ChainInformationConsensusRef<'a>,
 
-    /// See equivalent field in [`ChainInformation`].
-    pub grandpa_after_finalized_block_authorities_set_id: u64,
-
-    /// See equivalent field in [`ChainInformation`].
-    pub grandpa_finalized_triggered_authorities: &'a [header::GrandpaAuthority],
-
-    /// See equivalent field in [`ChainInformation`].
-    pub grandpa_finalized_scheduled_change: Option<(u64, &'a [header::GrandpaAuthority])>,
+    /// Extra items that depend on the finality engine.
+    pub finality: ChainInformationFinalityRef<'a>,
 }
 
 impl<'a> From<&'a ChainInformation> for ChainInformationRef<'a> {
@@ -333,13 +342,20 @@ impl<'a> From<&'a ChainInformation> for ChainInformationRef<'a> {
                     finalized_next_epoch_transition: finalized_next_epoch_transition.into(),
                 },
             },
-            grandpa_after_finalized_block_authorities_set_id: info
-                .grandpa_after_finalized_block_authorities_set_id,
-            grandpa_finalized_triggered_authorities: &info.grandpa_finalized_triggered_authorities,
-            grandpa_finalized_scheduled_change: info
-                .grandpa_finalized_scheduled_change
-                .as_ref()
-                .map(|(n, l)| (*n, &l[..])),
+            finality: match &info.finality {
+                ChainInformationFinality::Grandpa {
+                    finalized_triggered_authorities,
+                    after_finalized_block_authorities_set_id,
+                    finalized_scheduled_change,
+                } => ChainInformationFinalityRef::Grandpa {
+                    after_finalized_block_authorities_set_id:
+                        *after_finalized_block_authorities_set_id,
+                    finalized_triggered_authorities,
+                    finalized_scheduled_change: finalized_scheduled_change
+                        .as_ref()
+                        .map(|(n, l)| (*n, &l[..])),
+                },
+            },
         }
     }
 }
@@ -402,4 +418,19 @@ impl<'a> From<&'a BabeEpochInformation> for BabeEpochInformationRef<'a> {
             allowed_slots: info.allowed_slots,
         }
     }
+}
+
+/// Extra items that depend on the finality engine.
+#[derive(Debug, Clone)]
+pub enum ChainInformationFinalityRef<'a> {
+    Grandpa {
+        /// See equivalent field in [`ChainInformationFinality`].
+        after_finalized_block_authorities_set_id: u64,
+
+        /// See equivalent field in [`ChainInformationFinality`].
+        finalized_triggered_authorities: &'a [header::GrandpaAuthority],
+
+        /// See equivalent field in [`ChainInformationFinality`].
+        finalized_scheduled_change: Option<(u64, &'a [header::GrandpaAuthority])>,
+    },
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -35,7 +35,7 @@
 //!
 
 use crate::chain::chain_information::{
-    BabeEpochInformation, ChainInformation, ChainInformationConsensus,
+    BabeEpochInformation, ChainInformation, ChainInformationConsensus, ChainInformationFinality,
 };
 use alloc::string::String;
 use core::num::NonZeroU64;
@@ -97,22 +97,21 @@ impl LightSyncState {
                 finalized_block_epoch_information: Some(convert_epoch(current_epoch)),
                 finalized_next_epoch_transition: convert_epoch(next_epoch),
             },
-            grandpa_after_finalized_block_authorities_set_id: self
-                .inner
-                .grandpa_authority_set
-                .set_id,
-            grandpa_finalized_triggered_authorities: {
-                self.inner
-                    .grandpa_authority_set
-                    .current_authorities
-                    .iter()
-                    .map(|authority| crate::header::GrandpaAuthority {
-                        public_key: authority.public_key,
-                        weight: NonZeroU64::new(authority.weight).unwrap(),
-                    })
-                    .collect()
+            finality: ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id: self.inner.grandpa_authority_set.set_id,
+                finalized_triggered_authorities: {
+                    self.inner
+                        .grandpa_authority_set
+                        .current_authorities
+                        .iter()
+                        .map(|authority| crate::header::GrandpaAuthority {
+                            public_key: authority.public_key,
+                            weight: NonZeroU64::new(authority.weight).unwrap(),
+                        })
+                        .collect()
+                },
+                finalized_scheduled_change: None, // TODO: unimplemented
             },
-            grandpa_finalized_scheduled_change: None, // TODO: unimplemented
         }
     }
 }

--- a/src/database/full_sled/open.rs
+++ b/src/database/full_sled/open.rs
@@ -220,29 +220,39 @@ impl DatabaseEmpty {
                             .number
                             .to_be_bytes()[..],
                     )?;
-                    meta.insert(
-                        b"grandpa_authorities_set_id",
-                        &chain_information
-                            .grandpa_after_finalized_block_authorities_set_id
-                            .to_be_bytes()[..],
-                    )?;
-                    meta.insert(
-                        b"grandpa_triggered_authorities",
-                        encode_grandpa_authorities_list(header::GrandpaAuthoritiesIter::new(
-                            &chain_information.grandpa_finalized_triggered_authorities,
-                        )),
-                    )?;
 
-                    if let Some((height, list)) =
-                        &chain_information.grandpa_finalized_scheduled_change
-                    {
-                        meta.insert(b"grandpa_scheduled_target", &height.to_be_bytes()[..])?;
-                        meta.insert(
-                            b"grandpa_scheduled_authorities",
-                            encode_grandpa_authorities_list(header::GrandpaAuthoritiesIter::new(
-                                list,
-                            )),
-                        )?;
+                    match &chain_information.finality {
+                        chain_information::ChainInformationFinalityRef::Grandpa {
+                            finalized_triggered_authorities,
+                            after_finalized_block_authorities_set_id,
+                            finalized_scheduled_change,
+                        } => {
+                            meta.insert(
+                                b"grandpa_authorities_set_id",
+                                &after_finalized_block_authorities_set_id.to_be_bytes()[..],
+                            )?;
+                            meta.insert(
+                                b"grandpa_triggered_authorities",
+                                encode_grandpa_authorities_list(
+                                    header::GrandpaAuthoritiesIter::new(
+                                        finalized_triggered_authorities,
+                                    ),
+                                ),
+                            )?;
+
+                            if let Some((height, list)) = finalized_scheduled_change {
+                                meta.insert(
+                                    b"grandpa_scheduled_target",
+                                    &height.to_be_bytes()[..],
+                                )?;
+                                meta.insert(
+                                    b"grandpa_scheduled_authorities",
+                                    encode_grandpa_authorities_list(
+                                        header::GrandpaAuthoritiesIter::new(list),
+                                    ),
+                                )?;
+                            }
+                        }
                     }
 
                     match &chain_information.consensus {

--- a/src/finality/justification/decode.rs
+++ b/src/finality/justification/decode.rs
@@ -21,6 +21,7 @@ use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt};
 
 /// Attempt to decode the given SCALE-encoded justification.
+// TODO: shouldn't this method be specific to Grandpa?
 pub fn decode<'a>(scale_encoded: &'a [u8]) -> Result<JustificationRef<'a>, Error> {
     match nom::combinator::all_consuming(justification)(scale_encoded) {
         Ok((_, justification)) => Ok(justification),


### PR DESCRIPTION
cc #221 

Changes `ChainInformation` and extracts all the Grandpa field to an enum `ChainInformationFinality`. This enum contains only one variant at the moment `Grandpa`, but the idea is to add a new `RelayChain`/`Manual` variant later.

Some notes:

- The format of justifications doesn't contain any indication about which engine they refer to, and therefore we have to deduce it based on the finality engine of the chain. If we add a `Manual` variant, `verify_justification` would always return an error.
- `NonFinalizedTree::set_finalized_block` would work just fine. All this method does regarding Grandpa is go through the headers of the finalized blocks and update the state of Grandpa. If there's no Grandpa, there's just no state update.
- The Grandpa-related database fields are still mandatory. While I added comments mentioning that they're optional if the chain doesn't use Grandpa, the database code at some point has to create a `ChainInformationFinality`, and the only possible variant is `Grandpa`. If the fields are missing, there's not much I can do except return an error.
