### PR TITLE
Add an AllAuthorized consensus engine

### DIFF
--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -69,60 +69,67 @@ impl ChainInformation {
     pub fn from_genesis_storage<'a>(
         genesis_storage: impl Iterator<Item = (&'a [u8], &'a [u8])> + Clone,
     ) -> Result<Self, FromGenesisStorageError> {
-        let babe_genesis_config = babe::BabeGenesisConfiguration::from_genesis_storage(|k| {
-            genesis_storage
-                .clone()
-                .find(|(k2, _)| *k2 == k)
-                .map(|(_, v)| v.to_owned())
-        })
-        .ok(); // TODO: differentiate between errors and lack of Babe
-
-        let grandpa_genesis_config =
-            grandpa::chain_config::GrandpaGenesisConfiguration::from_genesis_storage(|key| {
-                genesis_storage
-                    .clone()
-                    .find(|(k, _)| *k == key)
-                    .map(|(_, v)| v.to_owned())
-            })
-            .unwrap();
-
-        let consensus = if let Some(babe_genesis_config) = babe_genesis_config {
-            ChainInformationConsensus::Babe {
-                slots_per_epoch: babe_genesis_config.slots_per_epoch,
-                finalized_block_epoch_information: None,
-                finalized_next_epoch_transition: BabeEpochInformation {
-                    epoch_index: 0,
-                    start_slot_number: None,
-                    authorities: babe_genesis_config.epoch0_information.authorities,
-                    randomness: babe_genesis_config.epoch0_information.randomness,
-                    c: babe_genesis_config.epoch0_configuration.c,
-                    allowed_slots: babe_genesis_config.epoch0_configuration.allowed_slots,
-                },
-            }
-        } else {
-            // If not Babe, we assume Aura.
+        let consensus = {
             let aura_genesis_config = aura::AuraGenesisConfiguration::from_genesis_storage(|k| {
                 genesis_storage
                     .clone()
                     .find(|(k2, _)| *k2 == k)
                     .map(|(_, v)| v.to_owned())
             })
-            .unwrap(); // TODO: don't unwrap
+            .ok(); // TODO: differentiate between errors and lack of Aura
 
-            ChainInformationConsensus::Aura {
-                finalized_authorities_list: aura_genesis_config.authorities_list,
-                slot_duration: aura_genesis_config.slot_duration,
+            let babe_genesis_config = babe::BabeGenesisConfiguration::from_genesis_storage(|k| {
+                genesis_storage
+                    .clone()
+                    .find(|(k2, _)| *k2 == k)
+                    .map(|(_, v)| v.to_owned())
+            })
+            .ok(); // TODO: differentiate between errors and lack of Babe
+
+            match (aura_genesis_config, babe_genesis_config) {
+                (Some(aura_genesis_config), None) => ChainInformationConsensus::Aura {
+                    finalized_authorities_list: aura_genesis_config.authorities_list,
+                    slot_duration: aura_genesis_config.slot_duration,
+                },
+                (None, Some(babe_genesis_config)) => ChainInformationConsensus::Babe {
+                    slots_per_epoch: babe_genesis_config.slots_per_epoch,
+                    finalized_block_epoch_information: None,
+                    finalized_next_epoch_transition: BabeEpochInformation {
+                        epoch_index: 0,
+                        start_slot_number: None,
+                        authorities: babe_genesis_config.epoch0_information.authorities,
+                        randomness: babe_genesis_config.epoch0_information.randomness,
+                        c: babe_genesis_config.epoch0_configuration.c,
+                        allowed_slots: babe_genesis_config.epoch0_configuration.allowed_slots,
+                    },
+                },
+                (None, None) => ChainInformationConsensus::AllAuthorized, // TODO: seems a bit risky to automatically fall back to this?
+                (Some(_), Some(_)) => {
+                    return Err(FromGenesisStorageError::MultipleConsensusAlgorithms);
+                }
+            }
+        };
+
+        let finality = {
+            let grandpa_genesis_config =
+                grandpa::chain_config::GrandpaGenesisConfiguration::from_genesis_storage(|key| {
+                    genesis_storage
+                        .clone()
+                        .find(|(k, _)| *k == key)
+                        .map(|(_, v)| v.to_owned())
+                })
+                .unwrap();
+            ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id: 0,
+                finalized_scheduled_change: None,
+                finalized_triggered_authorities: grandpa_genesis_config.initial_authorities,
             }
         };
 
         Ok(ChainInformation {
             finalized_block_header: crate::calculate_genesis_block_header(genesis_storage),
             consensus,
-            finality: ChainInformationFinality::Grandpa {
-                after_finalized_block_authorities_set_id: 0,
-                finalized_scheduled_change: None,
-                finalized_triggered_authorities: grandpa_genesis_config.initial_authorities,
-            },
+            finality,
         })
     }
 }
@@ -305,6 +312,8 @@ pub enum ChainInformationFinality {
 pub enum FromGenesisStorageError {
     /// Error when retrieving the GrandPa configuration.
     GrandpaConfigLoad(grandpa::chain_config::FromGenesisStorageError),
+    /// Multiple consensus algorithms have been detected.
+    MultipleConsensusAlgorithms,
 }
 
 #[derive(Debug, Clone)]

--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -132,6 +132,9 @@ impl<'a> From<ChainInformationRef<'a>> for ChainInformation {
         ChainInformation {
             finalized_block_header: info.finalized_block_header.into(),
             consensus: match info.consensus {
+                ChainInformationConsensusRef::AllAuthorized => {
+                    ChainInformationConsensus::AllAuthorized
+                }
                 ChainInformationConsensusRef::Aura {
                     finalized_authorities_list,
                     slot_duration,
@@ -171,6 +174,13 @@ impl<'a> From<ChainInformationRef<'a>> for ChainInformation {
 /// Extra items that depend on the consensus engine.
 #[derive(Debug, Clone)]
 pub enum ChainInformationConsensus {
+    /// Any node on the chain is allowed to produce blocks.
+    ///
+    /// > **Note**: Be warned that this variant makes it possible for a huge number of blocks to
+    /// >           be produced. If this variant is used, the user is encouraged to limit, through
+    /// >           other means, the number of blocks being accepted.
+    AllAuthorized,
+
     /// Chain is using the Aura consensus engine.
     Aura {
         /// List of authorities that must validate children of the block referred to by
@@ -321,6 +331,9 @@ impl<'a> From<&'a ChainInformation> for ChainInformationRef<'a> {
         ChainInformationRef {
             finalized_block_header: (&info.finalized_block_header).into(),
             consensus: match &info.consensus {
+                ChainInformationConsensus::AllAuthorized => {
+                    ChainInformationConsensusRef::AllAuthorized
+                }
                 ChainInformationConsensus::Aura {
                     finalized_authorities_list,
                     slot_duration,
@@ -363,6 +376,9 @@ impl<'a> From<&'a ChainInformation> for ChainInformationRef<'a> {
 /// Extra items that depend on the consensus engine.
 #[derive(Debug, Clone)]
 pub enum ChainInformationConsensusRef<'a> {
+    /// See [`ChainInformationConsensus::AllAuthorized`].
+    AllAuthorized,
+
     /// Chain is using the Aura consensus engine.
     Aura {
         /// See equivalent field in [`ChainInformationConsensus`].

--- a/src/database/full_sled/open.rs
+++ b/src/database/full_sled/open.rs
@@ -256,6 +256,7 @@ impl DatabaseEmpty {
                     }
 
                     match &chain_information.consensus {
+                        chain_information::ChainInformationConsensusRef::AllAuthorized => {}
                         chain_information::ChainInformationConsensusRef::Aura {
                             finalized_authorities_list,
                             slot_duration,

--- a/src/verify/header_only.rs
+++ b/src/verify/header_only.rs
@@ -43,6 +43,15 @@ pub struct Config<'a> {
 
 /// Extra items of [`Config`] that are dependant on the consensus engine of the chain.
 pub enum ConfigConsensus<'a> {
+    /// Any node on the chain is allowed to produce blocks.
+    ///
+    /// No seal must be present in the header.  // TODO: is this true?
+    ///
+    /// > **Note**: Be warned that this variant makes it possible for a huge number of blocks to
+    /// >           be produced. If this variant is used, the user is encouraged to limit, through
+    /// >           other means, the number of blocks being accepted.
+    AllAuthorized,
+
     /// Chain is using the Aura consensus engine.
     Aura {
         /// Aura authorities that must validate the block.
@@ -81,10 +90,16 @@ pub enum ConfigConsensus<'a> {
 
 /// Block successfully verified.
 pub enum Success {
+    /// [`ConfigConsensus::AllAuthorized`] was passed to [`Config`].
+    AllAuthorized,
+
+    /// Chain is using the Aura consensus engine.
     Aura {
         /// True if the list of authorities is modified by this block.
         authorities_change: bool,
     },
+
+    /// Chain is using the Babe consensus engine.
     Babe {
         /// Slot number the block belongs to.
         ///
@@ -145,6 +160,15 @@ pub fn verify<'a>(config: Config<'a>) -> Result<Success, Error> {
     // TODO: need to verify that there's no grandpa scheduled change header if there's already an active grandpa scheduled change
 
     match config.consensus {
+        ConfigConsensus::AllAuthorized => {
+            if config.block_header.digest.has_any_aura()
+                || config.block_header.digest.has_any_babe()
+            {
+                return Err(Error::MultipleConsensusEngines);
+            }
+
+            Ok(Success::AllAuthorized)
+        }
         ConfigConsensus::Aura {
             current_authorities,
             slot_duration,


### PR DESCRIPTION
cc #221 

With `AllAuthorized`, any node has the permission to submit a block at any time. :cowboy_hat_face: 

Intended to be used for parachains, at least until Cumulus supports Aura/Babe.
