### PR TITLE
Fix database reporting as corrupted with AllAuthorized consensus

### DIFF
--- a/src/database/full_sled.rs
+++ b/src/database/full_sled.rs
@@ -401,6 +401,9 @@ impl SledFullDatabase {
                             slot_duration,
                         }
                     }
+                    (None, None, None, None) => {
+                        chain_information::ChainInformationConsensus::AllAuthorized
+                    }
                     _ => {
                         return Err(sled::transaction::ConflictableTransactionError::Abort(
                             FinalizedAccessError::Access(AccessError::Corrupted(


### PR DESCRIPTION
If no Aura/Babe field is found, reporting as `AllAuthorized` instead of returning an error.