### PR TITLE
Update the full node code and informant for parachains

### DIFF
--- a/bin/tick_v1.json
+++ b/bin/tick_v1.json
@@ -17,7 +17,7 @@
     "tokenDecimals": 12,
     "tokenSymbol": "ROC"
   },
-  "relay_chain": "rococo",
+  "relay_chain": "rococo_v1",
   "para_id": 100,
   "consensusEngine": null,
   "genesis": {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -199,6 +199,14 @@ impl ChainSpec {
             .unwrap_or("sup")
     }
 
+    // TODO: this API is probably unstable, as the meaning of the string is unclear
+    pub fn relay_chain(&self) -> Option<(&str, u32)> {
+        self.client_spec
+            .parachain
+            .as_ref()
+            .map(|p| (p.relay_chain.as_str(), p.para_id))
+    }
+
     /// Returns the list of storage keys and values of the genesis block.
     pub fn genesis_storage(&self) -> impl ExactSizeIterator<Item = (&[u8], &[u8])> + Clone {
         let structs::Genesis::Raw(genesis) = &self.client_spec.genesis;

--- a/src/informant.rs
+++ b/src/informant.rs
@@ -57,6 +57,8 @@ pub struct InformantLine<'a> {
     pub enable_colors: bool,
     /// Name of the chain.
     pub chain_name: &'a str,
+    /// Extra fields related to the relay chain.
+    pub relay_chain: Option<RelayChain<'a>>,
     /// Maximum number of characters of the informant line.
     pub max_line_width: u32,
     /// Number of network connections we are having with the rest of the peer-to-peer network.
@@ -73,6 +75,15 @@ pub struct InformantLine<'a> {
     pub finalized_hash: &'a [u8],
 }
 
+/// Extra fields if a relay chain exists.
+#[derive(Debug)]
+pub struct RelayChain<'a> {
+    /// Name of the chain.
+    pub chain_name: &'a str,
+    /// Number of the best block that we have locally.
+    pub best_number: u64,
+}
+
 impl<'a> fmt::Display for InformantLine<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: lots of allocations in here
@@ -81,18 +92,37 @@ impl<'a> fmt::Display for InformantLine<'a> {
         // Define the escape sequences used below for colouring purposes.
         let cyan = if self.enable_colors { "\x1b[36m" } else { "" };
         let white_bold = if self.enable_colors { "\x1b[1;37m" } else { "" };
+        let light_gray = if self.enable_colors { "\x1b[90m" } else { "" };
         let reset = if self.enable_colors { "\x1b[0m" } else { "" };
 
-        let header = format!(
-            "    {cyan}{chain_name}{reset}   {white_bold}#{local_best:<7}{reset} [",
-            cyan = cyan,
-            reset = reset,
-            white_bold = white_bold,
-            chain_name = self.chain_name,
-            local_best = self.best_number,
-        );
+        let (header, header_len) = if let Some(relay_chain) = &self.relay_chain {
+            let header = format!(
+                "    {cyan}{chain_name}{reset}   {white_bold}#{local_best:<7}{reset} {light_gray}({relay_chain_name} #{relay_best}){reset} [",
+                cyan = cyan,
+                reset = reset,
+                white_bold = white_bold,
+                light_gray = light_gray,
+                chain_name = self.chain_name,
+                relay_chain_name = relay_chain.chain_name,
+                local_best = self.best_number,
+                relay_best = relay_chain.best_number,
+            );
 
-        let header_len = self.chain_name.chars().count() + 17; // TODO: ? it's easier to do that than deal with unicode
+            let header_len = self.chain_name.chars().count() + relay_chain.chain_name.len() + 27; // TODO: ? it's easier to do that than deal with unicode
+            (header, header_len)
+        } else {
+            let header = format!(
+                "    {cyan}{chain_name}{reset}   {white_bold}#{local_best:<7}{reset} [",
+                cyan = cyan,
+                reset = reset,
+                white_bold = white_bold,
+                chain_name = self.chain_name,
+                local_best = self.best_number,
+            );
+
+            let header_len = self.chain_name.chars().count() + 17; // TODO: ? it's easier to do that than deal with unicode
+            (header, header_len)
+        };
 
         // TODO: it's a bit of a clusterfuck to properly align because the emoji eats a whitespace
         let trailer = format!(

--- a/src/informant.rs
+++ b/src/informant.rs
@@ -33,6 +33,7 @@
 //! eprint!("{}\r", InformantLine {
 //!     enable_colors: true,
 //!     chain_name: "My chain",
+//!     relay_chain: None,
 //!     max_line_width: 80,
 //!     num_network_connections: 12,
 //!     best_number: 220,


### PR DESCRIPTION
cc #221 

When some chain specs contain a parachain name, we try to load `<parachain>.json` in the same directory. This is kind of hacky, but I don't know of any better solution nor if the chain specs format will change in the future.

This PR makes us load the relay chain specs, start a sync service for the relay chain, and show it in the informant.
The syncing of the relay chain doesn't work yet because the network doesn't support multiple chains at a time.
