### PR TITLE
Tweak storage queries for light-browser client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+
+[[package]]
+name = "ahash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "865f8b0b3fced577b7df82e9b0eb7609595d7209c0b39e78d0646672e244b1b1"
@@ -1083,6 +1089,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
+ "ahash 0.4.6",
  "serde",
 ]
 
@@ -1264,6 +1271,15 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+dependencies = [
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -2188,7 +2204,7 @@ dependencies = [
 name = "substrate-lite"
 version = "0.1.0"
 dependencies = [
- "ahash",
+ "ahash 0.6.1",
  "arrayvec 0.5.2",
  "async-std",
  "blake2-rfc",
@@ -2261,6 +2277,7 @@ dependencies = [
  "derive_more",
  "futures",
  "lazy_static",
+ "lru",
  "rand",
  "serde_json",
  "slab",

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 derive_more = "0.99.11"
 futures = "0.3.8"
 lazy_static = "1.4.0"
+lru = "0.6.1"
 rand = "0.7.3"
 serde_json = "1.0.59"
 slab = "0.4.2"

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -26,12 +26,14 @@ use futures::prelude::*;
 use std::{
     collections::{BTreeMap, HashSet},
     convert::TryFrom as _,
+    iter,
     sync::Arc,
 };
 use substrate_lite::{
     chain, chain_spec,
     json_rpc::{self, methods},
-    network::{multiaddr, peer_id::PeerId},
+    network::{multiaddr, peer_id::PeerId, protocol},
+    trie::proof_verify,
 };
 
 pub mod ffi;
@@ -121,18 +123,31 @@ pub async fn start_client(chain_spec: String) {
         substrate_lite::metadata::metadata_from_runtime_code(code, heap_pages).unwrap()
     };
 
-    let mut client = Client {
-        chain_spec,
-        best_block: chain_information.finalized_block_header.clone(),
-        finalized_block: chain_information.finalized_block_header,
-        genesis_storage,
-        best_block_metadata,
-        next_subscription: 0,
-        runtime_version: HashSet::new(),
-        all_heads: HashSet::new(),
-        new_heads: HashSet::new(),
-        finalized_heads: HashSet::new(),
-        storage: HashSet::new(),
+    let mut client = {
+        let finalized_block_hash = chain_information.finalized_block_header.hash();
+
+        let mut known_blocks = lru::LruCache::new(256);
+        known_blocks.put(
+            finalized_block_hash,
+            chain_information.finalized_block_header.clone(),
+        );
+
+        Client {
+            chain_spec,
+            network_service: network_service.clone(),
+            peers: Vec::new(),
+            known_blocks,
+            best_block: finalized_block_hash,
+            finalized_block: finalized_block_hash,
+            genesis_storage,
+            best_block_metadata,
+            next_subscription: 0,
+            runtime_version: HashSet::new(),
+            all_heads: HashSet::new(),
+            new_heads: HashSet::new(),
+            finalized_heads: HashSet::new(),
+            storage: HashSet::new(),
+        }
     };
 
     loop {
@@ -140,9 +155,11 @@ pub async fn start_client(chain_spec: String) {
             network_message = network_service.next_event().fuse() => {
                 match network_message {
                     network_service::Event::Connected(peer_id) => {
+                        client.peers.push(peer_id.clone());
                         sync_service.add_source(peer_id).await;
                     }
                     network_service::Event::Disconnected(peer_id) => {
+                        client.peers.retain(|p| *p != peer_id);
                         sync_service.remove_source(peer_id).await;
                     }
                 }
@@ -187,7 +204,13 @@ pub async fn start_client(chain_spec: String) {
                             ffi::emit_json_rpc_response(&notification);
                         }
 
-                        client.best_block = decoded.into();
+                        client.best_block = decoded.hash();
+                        client.known_blocks.put(client.best_block, decoded.into());
+
+                        // Load the entry of the finalized block in order to guarantee that it
+                        // remains in the LRU cache.
+                        let _ = client.known_blocks.get(&client.finalized_block).unwrap();
+
                         // TODO: need to update `best_block_metadata` if necessary, and notify the runtime version subscriptions
                     },
                     sync_service::Event::NewFinalized { scale_encoded_header } => {
@@ -203,13 +226,15 @@ pub async fn start_client(chain_spec: String) {
                             ffi::emit_json_rpc_response(&notification);
                         }
 
-                        client.finalized_block = decoded.into();
+                        client.finalized_block = decoded.hash();
+                        client.known_blocks.put(client.finalized_block, decoded.into());
                     },
                 }
             },
 
             json_rpc_request = ffi::next_json_rpc().fuse() => {
                 // TODO: don't unwrap
+                // TODO: don't await here; use a queue
                 let (response1, response2) = handle_rpc(&String::from_utf8(Vec::from(json_rpc_request)).unwrap(), &mut client).await;
                 ffi::emit_json_rpc_response(&response1);
                 if let Some(response2) = response2 {
@@ -223,11 +248,22 @@ pub async fn start_client(chain_spec: String) {
 struct Client {
     chain_spec: chain_spec::ChainSpec,
 
-    /// Current best block.
-    best_block: substrate_lite::header::Header,
-    /// Latest finalized block.
-    finalized_block: substrate_lite::header::Header,
+    network_service: Arc<network_service::NetworkService>,
 
+    /// Blocks that are temporarily saved in order to serve JSON-RPC requests.
+    ///
+    /// Always contains `best_block` and `finalized_block`.
+    known_blocks: lru::LruCache<[u8; 32], substrate_lite::header::Header>,
+
+    /// Hash of the current best block.
+    best_block: [u8; 32],
+    /// Hash of the latest finalized block.
+    finalized_block: [u8; 32],
+
+    // TODO: this is a hack before an actual requests distribution system is implemented
+    peers: Vec<PeerId>,
+
+    // TODO: remove; unnecessary
     genesis_storage: BTreeMap<Vec<u8>, Vec<u8>>,
 
     best_block_metadata: Vec<u8>,
@@ -252,10 +288,8 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
         methods::MethodCall::chain_getBlockHash { height } => {
             // TODO: implement correctly
             let response = if height.is_some() {
-                methods::Response::chain_getBlockHash(methods::HashHexString(
-                    client.best_block.hash(),
-                ))
-                .to_json_response(request_id)
+                methods::Response::chain_getBlockHash(methods::HashHexString(client.best_block))
+                    .to_json_response(request_id)
             } else {
                 json_rpc::parse::build_success_response(request_id, "null")
             };
@@ -263,26 +297,19 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
         }
         methods::MethodCall::chain_getFinalizedHead {} => {
             let response = methods::Response::chain_getFinalizedHead(methods::HashHexString(
-                client.finalized_block.hash(),
+                client.finalized_block,
             ))
             .to_json_response(request_id);
             (response, None)
         }
         methods::MethodCall::chain_getHeader { hash } => {
-            let response = if let Some(hash) = hash {
-                if hash.0 == client.best_block.hash() {
-                    methods::Response::chain_getHeader(header_conv(&client.best_block))
-                        .to_json_response(request_id)
-                } else if hash.0 == client.finalized_block.hash() {
-                    methods::Response::chain_getHeader(header_conv(&client.finalized_block))
-                        .to_json_response(request_id)
-                } else {
-                    json_rpc::parse::build_success_response(request_id, "null")
-                }
+            let hash = hash.as_ref().map(|h| &h.0).unwrap_or(&client.best_block);
+            let response = if let Some(header) = client.known_blocks.get(hash) {
+                methods::Response::chain_getHeader(header_conv(header)).to_json_response(request_id)
             } else {
-                methods::Response::chain_getHeader(header_conv(&client.best_block))
-                    .to_json_response(request_id)
+                json_rpc::parse::build_success_response(request_id, "null")
             };
+
             (response, None)
         }
         methods::MethodCall::chain_subscribeAllHeads {} => {
@@ -295,7 +322,10 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             let response2 = substrate_lite::json_rpc::parse::build_subscription_event(
                 "chain_allHeads", // TODO: is this string correct?
                 &subscription,
-                &serde_json::to_string(&header_conv(&client.best_block)).unwrap(),
+                &serde_json::to_string(&header_conv(
+                    client.known_blocks.get(&client.best_block).unwrap(),
+                ))
+                .unwrap(),
             );
 
             client.all_heads.insert(subscription.clone());
@@ -312,7 +342,10 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             let response2 = substrate_lite::json_rpc::parse::build_subscription_event(
                 "chain_newHead",
                 &subscription,
-                &serde_json::to_string(&header_conv(&client.best_block)).unwrap(),
+                &serde_json::to_string(&header_conv(
+                    client.known_blocks.get(&client.best_block).unwrap(),
+                ))
+                .unwrap(),
             );
 
             client.new_heads.insert(subscription.clone());
@@ -329,7 +362,10 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             let response2 = substrate_lite::json_rpc::parse::build_subscription_event(
                 "chain_finalizedHead",
                 &subscription,
-                &serde_json::to_string(&header_conv(&client.finalized_block)).unwrap(),
+                &serde_json::to_string(&header_conv(
+                    client.known_blocks.get(&client.finalized_block).unwrap(),
+                ))
+                .unwrap(),
             );
 
             client.finalized_heads.insert(subscription.clone());
@@ -353,20 +389,19 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             (response, None)
         }
         methods::MethodCall::state_queryStorageAt { keys, at } => {
-            // TODO: I have no idea what the API of this function is
-            assert!(at.is_none()); // TODO:
+            let at = at.as_ref().map(|h| h.0).unwrap_or(client.best_block);
 
+            // TODO: have no idea what this describes actually
             let mut out = methods::StorageChangeSet {
-                block: methods::HashHexString(client.best_block.hash()),
+                block: methods::HashHexString(client.best_block),
                 changes: Vec::new(),
             };
 
             for key in keys {
-                let value = client
-                    .genesis_storage
-                    .get(&key.0[..])
-                    .map(|v| methods::HexString(v.to_vec()));
-                out.changes.push((key, value));
+                // TODO: parallelism?
+                if let Ok(value) = storage_query(client, &key.0, &at).await {
+                    out.changes.push((key, value.map(methods::HexString)));
+                }
             }
 
             let response =
@@ -412,13 +447,15 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             (response, None)
         }
         methods::MethodCall::state_getStorage { key, hash } => {
-            // TODO: use hash
+            let hash = hash.as_ref().map(|h| h.0).unwrap_or(client.best_block);
 
-            let response = if let Some(value) = client.genesis_storage.get(&key.0[..]) {
-                methods::Response::state_getStorage(methods::HexString(value.clone()))
-                    .to_json_response(request_id)
-            } else {
-                json_rpc::parse::build_success_response(request_id, "null")
+            let response = match storage_query(client, &key.0, &hash).await {
+                Ok(Some(value)) => {
+                    methods::Response::state_getStorage(methods::HexString(value.to_owned())) // TODO: overhead
+                        .to_json_response(request_id)
+                }
+                Ok(None) => json_rpc::parse::build_success_response(request_id, "null"),
+                Err(()) => todo!(), // TODO:
             };
 
             (response, None)
@@ -454,16 +491,17 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
 
             // TODO: have no idea what this describes actually
             let mut out = methods::StorageChangeSet {
-                block: methods::HashHexString(client.best_block.hash()),
+                block: methods::HashHexString(client.best_block),
                 changes: Vec::new(),
             };
 
+            let best_block_hash = client.best_block;
+
             for key in list {
-                let value = client
-                    .genesis_storage
-                    .get(&key.0[..])
-                    .map(|v| methods::HexString(v.to_vec()));
-                out.changes.push((key, value));
+                // TODO: parallelism?
+                if let Ok(value) = storage_query(client, &key.0, &best_block_hash).await {
+                    out.changes.push((key, value.map(methods::HexString)));
+                }
             }
 
             // TODO: hack
@@ -472,6 +510,8 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
                 &subscription,
                 &serde_json::to_string(&out).unwrap(),
             );
+
+            // TODO: subscription not actually implemented
 
             (response1, Some(response2))
         }
@@ -539,6 +579,50 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             panic!(); // TODO:
         }
     }
+}
+
+async fn storage_query(
+    client: &mut Client,
+    key: &[u8],
+    hash: &[u8; 32],
+) -> Result<Option<Vec<u8>>, ()> {
+    let trie_root_hash = if let Some(header) = client.known_blocks.get(hash) {
+        Some(header.state_root)
+    } else {
+        None
+    };
+
+    let mut result = Err(());
+
+    for target in client.peers.iter() {
+        if trie_root_hash.is_none() || result.is_ok() {
+            break;
+        }
+
+        result = client
+            .network_service
+            .clone()
+            .storage_proof_request(
+                target.clone(),
+                protocol::StorageProofRequestConfig {
+                    block_hash: *hash,
+                    keys: iter::once(key),
+                },
+            )
+            .await
+            .map_err(|_| ())
+            .and_then(|outcome| {
+                proof_verify::verify_proof(proof_verify::Config {
+                    proof: outcome.iter().map(|nv| &nv[..]),
+                    requested_key: key,
+                    trie_root_hash: trie_root_hash.as_ref().unwrap(),
+                })
+                .map_err(|_| ())
+                .map(|v| v.map(|v| v.to_owned()))
+            });
+    }
+
+    result
 }
 
 fn header_conv<'a>(header: impl Into<substrate_lite::header::HeaderRef<'a>>) -> methods::Header {

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -594,7 +594,7 @@ async fn storage_query(
 
     let mut result = Err(());
 
-    for target in client.peers.iter() {
+    for target in client.peers.iter().take(3) {
         if trie_root_hash.is_none() || result.is_ok() {
             break;
         }

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -70,7 +70,7 @@ pub struct SyncService {
 
 impl SyncService {
     pub async fn new(mut config: Config) -> Self {
-        let (to_foreground, from_background) = mpsc::channel(16);
+        let (to_foreground, from_background) = mpsc::channel(1024);
         let (to_background, from_foreground) = mpsc::channel(16);
 
         (config.tasks_executor)(Box::pin(

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -70,7 +70,7 @@ pub struct SyncService {
 
 impl SyncService {
     pub async fn new(mut config: Config) -> Self {
-        let (to_foreground, from_background) = mpsc::channel(1024);
+        let (to_foreground, from_background) = mpsc::channel(256);
         let (to_background, from_foreground) = mpsc::channel(16);
 
         (config.tasks_executor)(Box::pin(

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -247,7 +247,6 @@ async fn start_sync(
             }
 
             let mut verified_blocks = 0u64;
-            let mut new_finalized = None;
 
             // Verify blocks that have been fetched from queries.
             // TODO: tweak this mechanism of stopping sync from time to time
@@ -260,7 +259,23 @@ async fn start_sync(
                     optimistic::ProcessOne::NewBest { sync: s, .. }
                     | optimistic::ProcessOne::Reset { sync: s, .. } => {
                         sync = s;
-                        verified_blocks += 1;
+
+                        let scale_encoded_header = sync.best_block_header().scale_encoding().fold(
+                            Vec::new(),
+                            |mut a, b| {
+                                a.extend_from_slice(b.as_ref());
+                                a
+                            },
+                        );
+                        if to_foreground
+                            .send(FromBackground::NewBest {
+                                scale_encoded_header,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
                     }
 
                     optimistic::ProcessOne::Finalized {
@@ -281,7 +296,25 @@ async fn start_sync(
                                 a
                             });
 
-                        new_finalized = Some(scale_encoded_header);
+                        if to_foreground
+                            .send(FromBackground::NewBest {
+                                scale_encoded_header: scale_encoded_header.clone(),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+
+                        if to_foreground
+                            .send(FromBackground::NewFinalized {
+                                scale_encoded_header,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
                     }
 
                     // Other variants can be produced if the sync state machine is configured for
@@ -295,38 +328,6 @@ async fn start_sync(
             // meanwhile, the `yield_once` function interrupts the current task and gives a
             // chance for other tasks to progress.
             crate::yield_once().await;
-
-            if verified_blocks != 0 {
-                let scale_encoded_header =
-                    sync.best_block_header()
-                        .scale_encoding()
-                        .fold(Vec::new(), |mut a, b| {
-                            a.extend_from_slice(b.as_ref());
-                            a
-                        });
-                if to_foreground
-                    .send(FromBackground::NewBest {
-                        scale_encoded_header,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-            }
-
-            if let Some(scale_encoded_header) = new_finalized {
-                debug_assert_ne!(verified_blocks, 0);
-                if to_foreground
-                    .send(FromBackground::NewFinalized {
-                        scale_encoded_header,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-            }
 
             futures::select! {
                 message = from_foreground.next() => {

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -70,7 +70,7 @@ pub struct SyncService {
 
 impl SyncService {
     pub async fn new(mut config: Config) -> Self {
-        let (to_foreground, from_background) = mpsc::channel(256);
+        let (to_foreground, from_background) = mpsc::channel(1024);
         let (to_background, from_foreground) = mpsc::channel(16);
 
         (config.tasks_executor)(Box::pin(


### PR DESCRIPTION
The sync service now reports every single block to the outside.

The JSON-RPC storage queries are now handled by asking for storage proofs from other nodes.
