### PR TITLE
Fix notification length prefix not being sent

### DIFF
--- a/src/network/connection/established.rs
+++ b/src/network/connection/established.rs
@@ -802,6 +802,7 @@ where
         if !matches!(substream.user_data(), Substream::NotificationsOut { .. }) {
             panic!()
         }
+        substream.write(leb128::encode_usize(notification.len()).collect());
         substream.write(notification)
     }
 


### PR DESCRIPTION
I realized right after #310 and shutting down my computer that we didn't send the length of the notification as we should.