### PR TITLE
Fix justifications not being downloaded

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -92,7 +92,7 @@ pub fn build_block_request(config: BlocksRequestConfig) -> impl Iterator<Item = 
             fields |= 1 << 25;
         }
         if config.fields.justification {
-            fields |= 1 << 26;
+            fields |= 1 << 28;
         }
 
         schema::BlockRequest {


### PR DESCRIPTION
Err, I didn't realize that https://github.com/paritytech/substrate-lite/pull/293 broke the justifications download.