### PR TITLE
Start the timers as soon as possible

### DIFF
--- a/bin/full-node/src/main.rs
+++ b/bin/full-node/src/main.rs
@@ -291,15 +291,19 @@ async fn async_main() {
         })
     };*/
 
-    let mut informant_timer = stream::unfold((), move |_| {
-        futures_timer::Delay::new(Duration::from_secs(1)).map(|_| Some(((), ())))
-    })
-    .map(|_| ());
+    let mut informant_timer = stream::once(future::ready(())).chain(
+        stream::unfold((), move |_| {
+            futures_timer::Delay::new(Duration::from_secs(1)).map(|_| Some(((), ())))
+        })
+        .map(|_| ()),
+    );
 
-    let mut telemetry_timer = stream::unfold((), move |_| {
-        futures_timer::Delay::new(Duration::from_secs(5)).map(|_| Some(((), ())))
-    })
-    .map(|_| ());
+    let mut telemetry_timer = stream::once(future::ready(())).chain(
+        stream::unfold((), move |_| {
+            futures_timer::Delay::new(Duration::from_secs(5)).map(|_| Some(((), ())))
+        })
+        .map(|_| ()),
+    );
 
     let mut network_known_best = None;
 


### PR DESCRIPTION
`stream::unfold` doesn't actually yield the initial seed, meaning that these two timers were starting respectively one and five seconds later than they're supposed to start.