### PR TITLE
Fix spurious 1ms delay in JS node

### DIFF
--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -73,9 +73,9 @@ export async function start(config) {
 
       // Must call `timer_finished` after the given number of milliseconds has elapsed.
       start_timer: (id, ms) => {
-        // In the browser, `setTimeout` works when `ms` equals 0. However, NodeJS accepts a
-        // minimum of 1 milliseconds (if `0` is passed, it is replaced with `1`) and wants you to
-        // use `setImmediate` instead.
+        // In browsers, `setTimeout` works as expected when `ms` equals 0. However, NodeJS
+        // requires a minimum of 1 millisecond (if `0` is passed, it is automatically replaced
+        // with `1`) and wants you to use `setImmediate` instead.
         if (ms == 0 && typeof setImmediate === "function") {
           setImmediate(() => {
             module.exports.timer_finished(id);

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -76,7 +76,7 @@ export async function start(config) {
         // In the browser, `setTimeout` works when `ms` equals 0. However, NodeJS accepts a
         // minimum of 1 milliseconds (if `0` is passed, it is replaced with `1`) and wants you to
         // use `setImmediate` instead.
-        if (ms == 0 && setImmediate) {
+        if (ms == 0 && typeof setImmediate === "function") {
           setImmediate(() => {
             module.exports.timer_finished(id);
           })

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -73,9 +73,18 @@ export async function start(config) {
 
       // Must call `timer_finished` after the given number of milliseconds has elapsed.
       start_timer: (id, ms) => {
-        setTimeout(() => {
-          module.exports.timer_finished(id);
-        }, ms)
+        // In the browser, `setTimeout` works when `ms` equals 0. However, NodeJS accepts a
+        // minimum of 1 milliseconds (if `0` is passed, it is replaced with `1`) and wants you to
+        // use `setImmediate` instead.
+        if (ms == 0 && setImmediate) {
+          setImmediate(() => {
+            module.exports.timer_finished(id);
+          })
+        } else {
+          setTimeout(() => {
+            module.exports.timer_finished(id);
+          }, ms)
+        }
       },
 
       // Must create a new WebSocket object. This implementation stores the created object in

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -112,10 +112,8 @@ pub(crate) fn spawn_task(future: impl Future<Output = ()> + Send + 'static) {
 fn start_timer_wrap(duration: Duration, closure: impl FnOnce()) {
     let callback: Box<Box<dyn FnOnce()>> = Box::new(Box::new(closure));
     let timer_id = u32::try_from(Box::into_raw(callback) as usize).unwrap();
-    let milliseconds = u64::try_from(duration.as_millis())
-        .unwrap_or(u64::max_value())
-        .saturating_add(1);
-    unsafe { bindings::start_timer(timer_id, milliseconds as f64) }
+    let milliseconds = u64::try_from(duration.as_millis()).unwrap_or(u64::max_value());
+    unsafe { bindings::start_timer(timer_id, (milliseconds as f64).ceil()) }
 }
 
 // TODO: cancel the timer if the `Delay` is destroyed? we create and destroy a lot of `Delay`s

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -77,8 +77,7 @@ pub(crate) fn spawn_task(future: impl Future<Output = ()> + Send + 'static) {
             }
 
             let arc_self = arc_self.clone();
-            // TODO: this extra 1ms is quite bad/annoying
-            start_timer_wrap(Duration::from_millis(1), move || {
+            start_timer_wrap(Duration::new(0, 0), move || {
                 if arc_self.done.load(atomic::Ordering::SeqCst) {
                     return;
                 }

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -81,11 +81,13 @@ extern "C" {
     /// >           also <https://github.com/dcodeIO/webassembly/issues/26#issuecomment-410157370>.
     pub fn monotonic_clock_ms() -> f64;
 
-    /// After `milliseconds` milliseconds have passed, must call [`timer_finished`] with the `id`
-    /// passed as parameter.
+    /// After at least `milliseconds` milliseconds have passed, must call [`timer_finished`] with
+    /// the `id` passed as parameter.
     ///
     /// When [`timer_finished`] is called, the value of [`monotonic_clock_ms`] must have increased
-    /// by the given number of `milliseconds`.
+    /// by at least the given number of `milliseconds`.
+    ///
+    /// If `milliseconds` is 0, [`timer_finished`] should be called as soon as possible.
     pub fn start_timer(id: u32, milliseconds: f64);
 
     /// Must initialize a new WebSocket connection that tries to connect to the given URL.


### PR DESCRIPTION
This was laziness from my side to pass 1 millisecond for the delay, even when want "immediate".