### PR TITLE
Block verification now also verifies new runtime

### DIFF
--- a/src/chain/sync/optimistic.rs
+++ b/src/chain/sync/optimistic.rs
@@ -825,6 +825,7 @@ impl<TRq, TSrc, TBl> ProcessOne<TRq, TSrc, TBl> {
                     offchain_storage_changes,
                     top_trie_root_calculation_cache,
                     parent_runtime,
+                    new_runtime, // TODO: make use of this
                     insert,
                 }) => {
                     // Successfully verified block!
@@ -962,6 +963,12 @@ impl<TRq, TSrc, TBl> ProcessOne<TRq, TSrc, TBl> {
                         inner: req,
                         shared,
                     });
+                }
+
+                Inner::Step2(blocks_tree::BodyVerifyStep2::RuntimeCompilation(c)) => {
+                    // The underlying verification process requires compiling a runtime code.
+                    inner = Inner::Step2(c.build());
+                    continue 'verif_steps;
                 }
 
                 // The three variants below correspond to problems during the verification.

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -195,6 +195,9 @@ pub struct HostVmPrototype {
     /// executor. Whenever the Wasm code invokes a host function, we obtain its index, and look
     /// within this `Vec` to know what to do.
     registered_functions: Vec<HostFunction>,
+
+    /// Value of `heap_pages` passed to [`HostVmPrototype::new`].
+    heap_pages: u64,
 }
 
 impl HostVmPrototype {
@@ -243,7 +246,13 @@ impl HostVmPrototype {
             vm_proto,
             heap_base,
             registered_functions,
+            heap_pages,
         })
+    }
+
+    /// Returns the number of heap pages that were passed to [`HostVmPrototype::new`].
+    pub fn heap_pages(&self) -> u64 {
+        self.heap_pages
     }
 
     /// Starts the VM, calling the function passed as parameter.
@@ -300,6 +309,7 @@ impl HostVmPrototype {
             inner: Inner {
                 vm,
                 heap_base: self.heap_base,
+                heap_pages: self.heap_pages,
                 registered_functions: self.registered_functions,
                 within_storage_transaction: false,
                 allocator,
@@ -1939,6 +1949,9 @@ struct Inner {
     /// allocator in case we need to rebuild the VM.
     heap_base: u32,
 
+    /// Value of `heap_pages` passed to [`HostVmPrototype::new`].
+    heap_pages: u64,
+
     /// If true, a transaction has been started using `ext_storage_start_transaction_version_1`.
     /// No further transaction start is allowed before the current one ends.
     within_storage_transaction: bool,
@@ -2065,6 +2078,7 @@ impl Inner {
             vm_proto: self.vm.into_prototype(),
             heap_base: self.heap_base,
             registered_functions: self.registered_functions,
+            heap_pages: self.heap_pages,
         }
     }
 }

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -598,6 +598,7 @@ impl Inner {
                 }
 
                 host::HostVm::CallRuntimeVersion(req) => {
+                    // TODO: make the user execute this ; see https://github.com/paritytech/substrate-lite/issues/144
                     // The code below compiles the provided WebAssembly runtime code, which is a
                     // relatively expensive operation (in the order of milliseconds).
                     // While it could be tempting to use a system cache, this function is expected


### PR DESCRIPTION
Fix #320 

In case of runtime upgrade, the block verification code now also compiles the new runtime.

Also relates to #144 
