### PR TITLE
Restore the database system of the Wasm node

### DIFF
--- a/bin/wasm-node/javascript/.gitignore
+++ b/bin/wasm-node/javascript/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+substrate-lite-demo-db.json

--- a/bin/wasm-node/javascript/demo.js
+++ b/bin/wasm-node/javascript/demo.js
@@ -21,18 +21,30 @@ import * as substrate_lite from './index.js';
 import { default as websocket } from 'websocket';
 import * as http from 'http';
 import { default as westend_specs } from './westend_specs.js';
+import * as fs from 'fs';
 
 let client = null;
 var unsent_queue = [];
 let ws_connection = null;
+const database_path = 'substrate-lite-demo-db.json';
+
+var database_content = null;
+try {
+    database_content = fs.readFileSync(database_path, 'utf8');
+} catch(error) {}
 
 substrate_lite.start({
     chain_spec: JSON.stringify(westend_specs()),
+    database_content: database_content,
     json_rpc_callback: (resp) => {
         if (ws_connection) {
             console.log("Sending back:", resp.slice(0, 100) + (resp.length > 100 ? '…' : ''));
             ws_connection.sendUTF(resp);
         }
+    },
+    database_save_callback: (db_content) => {
+        console.log("Saving database");
+        fs.writeFileSync(database_path, db_content);
     }
 })
     .then((c) => {

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -24,7 +24,9 @@ import { default as wasm_base64 } from './autogen/wasm.js';
 
 export async function start(config) {
   const chain_spec = config.chain_spec;
+  const database_content = config.database_content;
   const json_rpc_callback = config.json_rpc_callback;
+  const database_save_callback = config.database_save_callback;
 
   if (Object.prototype.toString.call(chain_spec) !== '[object String]')
     throw 'config must include a string chain_spec';
@@ -84,6 +86,14 @@ export async function start(config) {
           setTimeout(() => {
             module.exports.timer_finished(id);
           }, ms)
+        }
+      },
+
+      // Must set the content of the database to the given string.
+      database_save: (ptr, len) => {
+        if (database_save_callback) {
+          let content = Buffer.from(module.exports.memory.buffer).toString('utf8', ptr, ptr + len);
+          database_save_callback(content);
         }
       },
 
@@ -242,7 +252,14 @@ export async function start(config) {
   Buffer.from(module.exports.memory.buffer)
     .write(chain_spec, chain_spec_ptr);
 
-  module.exports.init(chain_spec_ptr, chain_spec_len, 0, 0);
+  let database_len = database_content ? Buffer.byteLength(database_content, 'utf8') : 0;
+  let database_ptr = (database_len != 0) ? module.exports.alloc(database_len) : 0;
+  if (database_len != 0) {
+    Buffer.from(module.exports.memory.buffer)
+      .write(database_content, database_ptr);
+  }
+
+  module.exports.init(chain_spec_ptr, chain_spec_len, database_ptr, database_len);
 
   return {
     send_json_rpc: (request) => {

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -90,6 +90,16 @@ extern "C" {
     /// If `milliseconds` is 0, [`timer_finished`] should be called as soon as possible.
     pub fn start_timer(id: u32, milliseconds: f64);
 
+    /// Client wants to set the content of the database to a UTF-8 string found at offset `ptr`
+    /// and with length `len`.
+    ///
+    /// The entire content of the database should be replaced with that string.
+    ///
+    /// This value is meant to later be passed to [`init`] when restarting the client.
+    ///
+    /// Saving the database is entirely optional, and it is legal to simply do nothing.
+    pub fn database_save(ptr: u32, len: u32);
+
     /// Must initialize a new WebSocket connection that tries to connect to the given URL.
     ///
     /// The URL is a UTF-8 string found in the WebAssembly memory at offset `url_ptr` and with


### PR DESCRIPTION
The demo will now save the state of the finalized chain every 15 seconds in `substrate-lite-demo-db.json`, and load it back on start-up.

The title of the PR says "restore", because this used to work a long time ago, and I broke it (intentionally) when removing the dependency on `wasm-bindgen`.
